### PR TITLE
Loading of comma and tab separated 3 column ascii files

### DIFF
--- a/EasyReflectometryApp/Logic/Proxies/Data.py
+++ b/EasyReflectometryApp/Logic/Proxies/Data.py
@@ -218,8 +218,9 @@ class DataProxy(QObject):
                 x, y, ye = data
                 xe = np.zeros_like(ye)
             else:
-                raise ValueError("The data must have at either 3 or 4 columns, \
-                                  and be tab or comma separated if not in the ORSO format")
+                msg = (" \nThe data must have at either 3 or 4 columns, "
+                        "and be tab or comma separated if not in the ORSO format")
+                raise ValueError(msg)
 
             name = path.split(file_path)[-1].split('.')[0]
             ds = DataSet1D(name=name, x=x, y=y, ye=ye, xe=xe, 

--- a/EasyReflectometryApp/Logic/Proxies/Data.py
+++ b/EasyReflectometryApp/Logic/Proxies/Data.py
@@ -209,14 +209,17 @@ class DataProxy(QObject):
                 self._data.append(ds)
         else:
             try:
-                x, y, ye, xe = np.loadtxt(file_path, unpack=True)
+                data = np.loadtxt(file_path, unpack=True)
             except ValueError:
-                try:
-                    x, y, ye = np.loadtxt(file_path, unpack=True)
-                    xe = np.zeros_like(ye)
-                except ValueError:
-                    x, y, ye = np.loadtxt(file_path, delimiter=',', unpack=True)
-                    xe = np.zeros_like(ye)
+                data = np.loadtxt(file_path, unpack=True, delimiter=',')
+            if data.shape[0] == 4:
+                x, y, ye, xe = data
+            elif data.shape[0] == 3:
+                x, y, ye = data
+                xe = np.zeros_like(ye)
+            else:
+                raise ValueError("The data must have at either 3 or 4 columns, \
+                                  and be tab or comma separated if not in the ORSO format")
 
             name = path.split(file_path)[-1].split('.')[0]
             ds = DataSet1D(name=name, x=x, y=y, ye=ye, xe=xe, 

--- a/EasyReflectometryApp/Logic/Proxies/Data.py
+++ b/EasyReflectometryApp/Logic/Proxies/Data.py
@@ -211,8 +211,13 @@ class DataProxy(QObject):
             try:
                 x, y, ye, xe = np.loadtxt(file_path, unpack=True)
             except ValueError:
-                x, y, ye = np.loadtxt(file_path, unpack=True)
-                xe = np.zeros_like(ye)
+                try:
+                    x, y, ye = np.loadtxt(file_path, unpack=True)
+                    xe = np.zeros_like(ye)
+                except ValueError:
+                    x, y, ye = np.loadtxt(file_path, delimiter=',', unpack=True)
+                    xe = np.zeros_like(ye)
+
             name = path.split(file_path)[-1].split('.')[0]
             ds = DataSet1D(name=name, x=x, y=y, ye=ye, xe=xe, 
                            model=self.parent._model_proxy._model[0], 


### PR DESCRIPTION
This fixes #94 by trying to load 3 column ascii files both with tab and comma separators. No tests added, but can be written if required.