### PR TITLE
Remove setup of private repo access

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,6 @@ jobs:
       - name: Check-out repository
         uses: actions/checkout@v2
 
-      - name: Set up access to private repos
-        uses: webfactory/ssh-agent@v0.5.2
-        with:
-          ssh-private-key: ${{ secrets.GH_WEBFACTORY_KEY }}
-
       - name: Set up non-Python dependences (Linux)
         if: runner.os == 'Linux'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Enable plotting of reflectometry data with a logarithmic q-axes [6c26411](https://github.com/easyScience/EasyReflectometryApp/commit/6c26411c5a4d4f412ce475b16d64e0c46a040e55)
 - Automatic transition to Sample tab after "Continue without project [31dfe4d](https://github.com/easyScience/EasyReflectometryApp/commit/31dfe4d6e3b2823bcc5420d26573a6cf5e20bad7)
+- Remove private repo access set from CI [f706d2a](https://github.com/easyScience/EasyReflectometryApp/pull/98/commits/f706d2af0aec333a9653616a1b88a7a51831d12c)
 
 ### Changes 0.0.5
 


### PR DESCRIPTION
The `build.yml` workflow had some cruft from an old version of easyDiffraction that has been removed with this PR