### PR TITLE
Fit to easyreflectometry 1.0.x and easyscience

### DIFF
--- a/.github/workflows/macos-windows-build.yml
+++ b/.github/workflows/macos-windows-build.yml
@@ -36,7 +36,7 @@ jobs:
             python-version: 3.9
 
       - name: Upgrade Pip
-        run: python -m pip install --upgrade pip
+        run: pip install --upgrade pip
 
       - name: Install with EasyReflectometry ci-dependencies
         run: pip install '.[ci]'

--- a/EasyReflectometryApp/Logic/DataStore.py
+++ b/EasyReflectometryApp/Logic/DataStore.py
@@ -1,14 +1,14 @@
 __author__ = 'github.com/wardsimon'
 
-from abc import abstractmethod
-from typing import Union, overload, TypeVar
+from typing import Union
+from typing import TypeVar
 
-from easyCore import np
-from easyCore.Objects.core import ComponentSerializer
-from easyCore.Utils.io.dict import DictSerializer
+import numpy as np
+from easyscience.Objects.core import ComponentSerializer
+from easyscience.Utils.io.dict import DictSerializer
 from collections.abc import Sequence
 
-from EasyReflectometry.experiment.model import Model
+from easyreflectometry.experiment.model import Model
 
 T = TypeVar('T')
 

--- a/EasyReflectometryApp/Logic/Proxies/Calculator.py
+++ b/EasyReflectometryApp/Logic/Proxies/Calculator.py
@@ -1,8 +1,10 @@
 __author__ = 'github.com/arm61'
 
-from PySide2.QtCore import QObject, Signal, Property
+from PySide2.QtCore import QObject
+from PySide2.QtCore import Signal
+from PySide2.QtCore import Property
 
-from easyCore.Utils.UndoRedo import property_stack_deco
+from easyscience.Utils.UndoRedo import property_stack_deco
 
 
 class CalculatorProxy(QObject):

--- a/EasyReflectometryApp/Logic/Proxies/Data.py
+++ b/EasyReflectometryApp/Logic/Proxies/Data.py
@@ -1,17 +1,20 @@
 __author__ = 'github.com/arm61'
 
-import pathlib
 from os import path
 from dicttoxml import dicttoxml
 
-from PySide2.QtCore import QObject, Signal, Property, Slot
+from PySide2.QtCore import QObject
+from PySide2.QtCore import Signal
+from PySide2.QtCore import Property
+from PySide2.QtCore import Slot
 
-from easyCore import np
+import numpy as np
 from easyApp.Logic.Utils.Utils import generalizePath
 
-from EasyReflectometryApp.Logic.DataStore import DataSet1D, DataStore
+from EasyReflectometryApp.Logic.DataStore import DataSet1D
+from EasyReflectometryApp.Logic.DataStore import DataStore
 
-from EasyReflectometry.data import load
+from easyreflectometry.data import load
 
 
 class DataProxy(QObject):

--- a/EasyReflectometryApp/Logic/Proxies/Fitter.py
+++ b/EasyReflectometryApp/Logic/Proxies/Fitter.py
@@ -1,12 +1,14 @@
 __author__ = 'github.com/arm61'
 
-import sys
+from PySide2.QtCore import Signal
+from PySide2.QtCore import QThread
+from PySide2.QtCore import QObject
+from PySide2.QtCore import Property
+from PySide2.QtCore import Slot
 
-from PySide2.QtCore import Signal, QThread, QObject, Property, Slot
+from easyscience import borg
 
-from easyCore import borg
-
-from EasyReflectometry.fitting import Fitter as easyFitter
+from easyreflectometry.fitting import Fitter as easyFitter
 
 
 class Fitter(QThread):

--- a/EasyReflectometryApp/Logic/Proxies/Material.py
+++ b/EasyReflectometryApp/Logic/Proxies/Material.py
@@ -1,5 +1,6 @@
 __author__ = 'github.com/arm61'
 
+import matplotlib
 from matplotlib import cm
 from matplotlib import colors
 
@@ -14,7 +15,7 @@ from easyscience.Utils.io.xml import XMLSerializer
 from easyreflectometry.sample import Material
 from easyreflectometry.sample import MaterialCollection
 
-COLOURMAP = cm.get_cmap('Blues', 100)
+COLOURMAP = matplotlib.colormaps['Blues'].resampled(100)
 MIN_SLD = -3
 MAX_SLD = 15
 

--- a/EasyReflectometryApp/Logic/Proxies/Material.py
+++ b/EasyReflectometryApp/Logic/Proxies/Material.py
@@ -1,14 +1,18 @@
 __author__ = 'github.com/arm61'
 
-from matplotlib import cm, colors
+from matplotlib import cm
+from matplotlib import colors
 
-from PySide2.QtCore import QObject, Signal, Property, Slot
+from PySide2.QtCore import QObject
+from PySide2.QtCore import Signal
+from PySide2.QtCore import Property
+from PySide2.QtCore import Slot
 
-from easyCore import borg
-from easyCore.Utils.io.xml import XMLSerializer
+from easyscience import borg
+from easyscience.Utils.io.xml import XMLSerializer
 
-from EasyReflectometry.sample import Material
-from EasyReflectometry.sample import MaterialCollection
+from easyreflectometry.sample import Material
+from easyreflectometry.sample import MaterialCollection
 
 COLOURMAP = cm.get_cmap('Blues', 100)
 MIN_SLD = -3
@@ -43,9 +47,9 @@ class MaterialProxy(QObject):
         :return: Three materials; Air, D2O and Si.
         """
         return MaterialCollection(
-            Material.from_pars(0., 0., name='Air'),
-            Material.from_pars(6.335, 0., name='D2O'),
-            Material.from_pars(2.074, 0., name='Si')
+            Material(0., 0., name='Air'),
+            Material(6.335, 0., name='D2O'),
+            Material(2.074, 0., name='Si')
         )
 
     # # #
@@ -114,7 +118,7 @@ class MaterialProxy(QObject):
         """
         borg.stack.enabled = False
         self._materials.append(
-            Material.from_pars(2.074,
+            Material(2.074,
                                0.000,
                                name=f'Si',
                                interface=self.parent._interface))
@@ -134,7 +138,7 @@ class MaterialProxy(QObject):
         # Manual duplication instead of creating a copy
         to_dup = self._materials[self.currentMaterialsIndex]
         self._materials.append(
-            Material.from_pars(to_dup.sld.raw_value,
+            Material(to_dup.sld.raw_value,
                                to_dup.isld.raw_value,
                                name=to_dup.name,
                                interface=self.parent._interface))

--- a/EasyReflectometryApp/Logic/Proxies/Material.py
+++ b/EasyReflectometryApp/Logic/Proxies/Material.py
@@ -47,9 +47,9 @@ class MaterialProxy(QObject):
         :return: Three materials; Air, D2O and Si.
         """
         return MaterialCollection(
-            Material(0., 0., name='Air'),
-            Material(6.335, 0., name='D2O'),
-            Material(2.074, 0., name='Si')
+            Material(sld=0., isld=0., name='Air'),
+            Material(sld=6.335, isld=0., name='D2O'),
+            Material(sld=2.074, isld=0., name='Si')
         )
 
     # # #
@@ -118,10 +118,13 @@ class MaterialProxy(QObject):
         """
         borg.stack.enabled = False
         self._materials.append(
-            Material(2.074,
-                               0.000,
-                               name=f'Si',
-                               interface=self.parent._interface))
+            Material(
+                sld=2.074,
+                isld=0.000,
+                name='Si',
+                interface=self.parent._interface
+            )
+        )
         borg.stack.enabled = True
         self.materialsChanged.emit()
         self.parent.layersMaterialsChanged.emit()
@@ -138,10 +141,13 @@ class MaterialProxy(QObject):
         # Manual duplication instead of creating a copy
         to_dup = self._materials[self.currentMaterialsIndex]
         self._materials.append(
-            Material(to_dup.sld.raw_value,
-                               to_dup.isld.raw_value,
-                               name=to_dup.name,
-                               interface=self.parent._interface))
+            Material(
+                sld=to_dup.sld.raw_value,
+                isld=to_dup.isld.raw_value,
+                name=to_dup.name,
+                interface=self.parent._interface
+            )
+        )
         borg.stack.enabled = True
         self.materialsChanged.emit()
         self.parent.layersMaterialsChanged.emit()

--- a/EasyReflectometryApp/Logic/Proxies/Material.py
+++ b/EasyReflectometryApp/Logic/Proxies/Material.py
@@ -1,7 +1,6 @@
 __author__ = 'github.com/arm61'
 
 import matplotlib
-from matplotlib import cm
 from matplotlib import colors
 
 from PySide2.QtCore import QObject

--- a/EasyReflectometryApp/Logic/Proxies/Minimizer.py
+++ b/EasyReflectometryApp/Logic/Proxies/Minimizer.py
@@ -1,8 +1,10 @@
 __author__ = 'github.com/arm61'
 
-from PySide2.QtCore import QObject, Signal, Property
+from PySide2.QtCore import QObject
+from PySide2.QtCore import Signal
+from PySide2.QtCore import Property
 
-from easyCore.Utils.UndoRedo import property_stack_deco
+from easyscience.Utils.UndoRedo import property_stack_deco
 
 
 class MinimizerProxy(QObject):

--- a/EasyReflectometryApp/Logic/Proxies/Model.py
+++ b/EasyReflectometryApp/Logic/Proxies/Model.py
@@ -62,18 +62,24 @@ class ModelProxy(QObject):
 
     def _defaultStructure(self) -> Sample:
         layers = [
-            Layer(self.parent._material_proxy._materials[0],
-                            0.0,
-                            0.0,
-                            name='Vacuum Layer'),
-            Layer(self.parent._material_proxy._materials[1],
-                            100.0,
-                            3.0,
-                            name='Multi-layer'),
-            Layer(self.parent._material_proxy._materials[2],
-                            0.0,
-                            1.2,
-                            name='Si Layer'),
+            Layer(
+                material=self.parent._material_proxy._materials[0],
+                thichness=0.0,
+                rougheness=0.0,
+                name='Vacuum Layer'
+            ),
+            Layer(
+                material=self.parent._material_proxy._materials[1],
+                thickness=100.0,
+                roughness=3.0,
+                name='Multi-layer'
+            ),
+            Layer(
+                material=self.parent._material_proxy._materials[2],
+                thickness=0.0,
+                roughness=1.2,
+                name='Si Layer'
+            ),
         ]
         items = [
             Multilayer(layers[0], name='Superphase'),
@@ -521,11 +527,14 @@ class ModelProxy(QObject):
             to_dup_layers = []
             for i in to_dup.layers:
                 to_dup_layers.append(
-                    Layer(i.material,
-                                    i.thickness.raw_value,
-                                    i.roughness.raw_value,
-                                    name=i.name,
-                                    interface=self.parent._interface))
+                    Layer(
+                        material=i.material,
+                        thickness=i.thickness.raw_value,
+                        roughness=i.roughness.raw_value,
+                        name=i.name,
+                        interface=self.parent._interface
+                    )
+                )
             dup_item = Multilayer(*to_dup_layers, name=to_dup.name)
         self._model[self.currentModelIndex].add_item(dup_item)
         self._model[self.currentModelIndex].sample[0].layers[0].thickness.enabled = False
@@ -644,11 +653,12 @@ class ModelProxy(QObject):
         try:
             self._model[self.currentModelIndex].sample[self.currentItemsIndex].add_layer(
                 Layer(
-                    self.parent._material_proxy._materials[0],
-                    10.0,
-                    1.2,
+                    material=self.parent._material_proxy._materials[0],
+                    thickness=10.0,
+                    roguhness=1.2,
                     name=f'Layer {len(self._model[self.currentModelIndex].sample[self.currentItemsIndex].layers)}'
-                ))
+                )
+            )
         except IndexError:
             self.addNewItems()
         self._model[self.currentModelIndex].sample[0].layers[0].thickness.enabled = False
@@ -666,10 +676,13 @@ class ModelProxy(QObject):
         to_dup = self._model[self.currentModelIndex].sample[self.currentItemsIndex].layers[
             self.currentLayersIndex]
         self._model[self.currentModelIndex].sample[self.currentItemsIndex].add_layer(
-            Layer(to_dup.material,
-                            to_dup.thickness.raw_value,
-                            to_dup.roughness.raw_value,
-                            name=to_dup.name))
+            Layer(
+                material=to_dup.material,
+                thickness=to_dup.thickness.raw_value,
+                roughness=to_dup.roughness.raw_value,
+                name=to_dup.name
+                )
+            )
         self._model[self.currentModelIndex].sample[0].layers[0].thickness.enabled = False
         self._model[self.currentModelIndex].sample[0].layers[0].roughness.enabled = False
         self._model[self.currentModelIndex].sample[-1].layers[-1].thickness.enabled = False

--- a/EasyReflectometryApp/Logic/Proxies/Model.py
+++ b/EasyReflectometryApp/Logic/Proxies/Model.py
@@ -17,7 +17,7 @@ from easyreflectometry.sample import SurfactantLayer
 from easyreflectometry.sample import Sample
 from easyreflectometry.experiment import Model
 from easyreflectometry.experiment import ModelCollection
-from easyreflectometry.experiment import percentage_fhwm_resolution_function
+from easyreflectometry.experiment import PercentageFhwm
 from easyreflectometry.calculators import CalculatorFactory
 
 ITEM_LOOKUP = {'Multi-layer': Multilayer, 'Repeating Multi-layer': RepeatingMultilayer, 'Surfactant Layer': SurfactantLayer}
@@ -87,12 +87,11 @@ class ModelProxy(QObject):
         return structure
 
     def _defaultModel(self, structure: Sample, interface=None, name="Air-D2O-Si") -> Model:
-        resolution_function = percentage_fhwm_resolution_function(0)
         return Model(
             sample=structure,
             scale=1,
             background=0,
-            resolution_function=resolution_function, 
+            resolution_function=PercentageFhwm(0), 
             interface=interface,
             name=name,
         )
@@ -361,12 +360,11 @@ class ModelProxy(QObject):
         sample = self._model[self.currentModelIndex].sample
         structure_dict = sample.as_dict()
 
-        resolution_function = percentage_fhwm_resolution_function(0)
         self._pure = Model(
             sample=Sample.from_dict(structure_dict),
             scale=1,
             background=0,
-            resolution_function=resolution_function, 
+            resolution_function=PercentageFhwm(0), 
             interface=self._pure_interface,
         )
 #        self._pure = Model(Sample.from_dict(structure_dict), 1, 0, 0, interface=self._pure_interface)

--- a/EasyReflectometryApp/Logic/Proxies/Model.py
+++ b/EasyReflectometryApp/Logic/Proxies/Model.py
@@ -250,7 +250,11 @@ class ModelProxy(QObject):
                 name=type
             )
         elif type == 'Surfactant Layer':
-            air = Material(0, 0, 'Air')
+            air = Material(
+                sld=0,
+                isld=0,
+                name='Air'
+            )
             tail_layer = LayerAreaPerMolecule(
                 molecular_formula='C32D64',
                 thickness=16,
@@ -260,7 +264,11 @@ class ModelProxy(QObject):
                 roughness=3,
                 name='DPPC Tail',
             )
-            d2o = Material(6.36, 0, 'D2O')
+            d2o = Material(
+                sld=6.36,
+                isld=0,
+                name='D2O'
+            )
             head_layer = LayerAreaPerMolecule(
                 molecular_formula='C10H18NO8P',
                 thickness=10.0,

--- a/EasyReflectometryApp/Logic/Proxies/Parameter.py
+++ b/EasyReflectometryApp/Logic/Proxies/Parameter.py
@@ -2,12 +2,17 @@ __author__ = 'github.com/arm61'
 
 from typing import Union
 from distutils.util import strtobool
-from PySide2.QtCore import QObject, Signal, Property, Slot
-from easyCore.Fitting.Constraints import ObjConstraint, NumericConstraint, FunctionalConstraint
-from easyCore.Utils.io.xml import XMLSerializer
-from easyCore import borg
-from easyCore import np
-from easyCore.Utils.classTools import generatePath
+from PySide2.QtCore import QObject
+from PySide2.QtCore import Signal
+from PySide2.QtCore import Property
+from PySide2.QtCore import Slot
+import numpy as np
+from easyscience.Fitting.Constraints import ObjConstraint
+from easyscience.Fitting.Constraints import NumericConstraint
+from easyscience.Fitting.Constraints import FunctionalConstraint
+from easyscience.Utils.io.xml import XMLSerializer
+from easyscience import borg
+from easyscience.Utils.classTools import generatePath
 
 
 class ParameterProxy(QObject):

--- a/EasyReflectometryApp/Logic/Proxies/Project.py
+++ b/EasyReflectometryApp/Logic/Proxies/Project.py
@@ -4,19 +4,20 @@ import os
 import datetime
 import json
 
-from PySide2.QtCore import QObject, Signal, Property, Slot
+from PySide2.QtCore import QObject
+from PySide2.QtCore import Signal
+from PySide2.QtCore import Property
+from PySide2.QtCore import Slot
 
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
-import matplotlib.backends.backend_pdf
 
-from easyCore import np
+import numpy as np
 from easyApp.Logic.Utils.Utils import generalizePath
 
 from EasyReflectometryApp.Logic.DataStore import DataSet1D
-from EasyReflectometry.sample import MaterialCollection
-from EasyReflectometry.experiment.model import Model
-from EasyReflectometry.experiment.models import Models
+from easyreflectometry.sample import MaterialCollection
+from easyreflectometry.experiment.model_collection import ModelCollection
 
 
 class ProjectProxy(QObject):
@@ -230,8 +231,8 @@ class ProjectProxy(QObject):
                     self.parent._interface.switch(inter)
 
         self.parent._model_proxy._colors = descr['colors']
-        self.parent._model_proxy._model = Models.from_dict(descr['model'])
-        self.parent._material_proxy._materials = MaterialCollection.from_pars()
+        self.parent._model_proxy._model = ModelCollection.from_dict(descr['model'])
+        self.parent._material_proxy._materials = MaterialCollection()
         for model in self.parent._model_proxy._model:
             for sample in model.sample:
                 for layer in sample.layers:

--- a/EasyReflectometryApp/Logic/Proxies/Project.py
+++ b/EasyReflectometryApp/Logic/Proxies/Project.py
@@ -152,34 +152,34 @@ class ProjectProxy(QObject):
         projectPath = self.currentProjectPath
         project_save_filepath = os.path.join(projectPath, 'project.json')
         materials_in_model = []
-        for i in self.parent._model_proxy._model:
-            for j in i.structure:
-                for k in j.layers:
-                    materials_in_model.append(k.material)
+        for model in self.parent._model_proxy._model:
+            for assembly in model.sample:
+                for layer in assembly.layers:
+                    materials_in_model.append(layer.material)
         materials_not_in_model = []
-        for i in self.parent._material_proxy._materials:
-            if i not in materials_in_model:
-                materials_not_in_model.append(i)
+        for material in self.parent._material_proxy._materials:
+            if material not in materials_in_model:
+                materials_not_in_model.append(material)
         descr = {
             'model':
                 self.parent._model_proxy._model.as_dict(skip=['interface']),
             'materials_not_in_model':
-                MaterialCollection(*materials_not_in_model).as_dict(skip=['interface'])
+                MaterialCollection(materials_not_in_model).as_dict(skip=['interface'])
         }
 
         if self.parent._data_proxy._data.experiments:
             descr['experiments'] = []
             descr['experiments_models'] = []
             descr['experiments_names'] = []
-            for i in self.parent._data_proxy._data.experiments:
+            for experiment in self.parent._data_proxy._data.experiments:
                 if self.parent._data_proxy._data.experiments[0].xe is not None:
                     descr['experiments'].append([
-                        i.x, i.y, i.ye, i.xe
+                        experiment.x, experiment.y, experiment.ye, experiment.xe
                     ])
                 else:
-                    descr['experiments'].append([i.x, i.y, i.ye])
-                descr['experiments_models'].append(i.model.name)
-                descr['experiments_names'].append(i.name)
+                    descr['experiments'].append([experiment.x, experiment.y, experiment.ye])
+                descr['experiments_models'].append(experiment.model.name)
+                descr['experiments_names'].append(experiment.name)
 
         descr['experiment_skipped'] = self.parent._data_proxy._experiment_skipped
         descr['project_info'] = self._project_info
@@ -232,7 +232,7 @@ class ProjectProxy(QObject):
 
         self.parent._model_proxy._colors = descr['colors']
         self.parent._model_proxy._model = ModelCollection.from_dict(descr['model'])
-        self.parent._material_proxy._materials = MaterialCollection()
+        self.parent._material_proxy._materials = MaterialCollection([])  # Should be initialized with empty list to enforce no elements in collection
         for model in self.parent._model_proxy._model:
             for sample in model.sample:
                 for layer in sample.layers:

--- a/EasyReflectometryApp/Logic/Proxies/Simulation.py
+++ b/EasyReflectometryApp/Logic/Proxies/Simulation.py
@@ -2,9 +2,12 @@ __author__ = 'github.com/arm61'
 
 import json
 
-from PySide2.QtCore import QObject, Signal, Property, Slot
+from PySide2.QtCore import QObject
+from PySide2.QtCore import Signal
+from PySide2.QtCore import Property
+from PySide2.QtCore import Slot
 
-from easyCore import np
+import numpy as np
 
 class SimulationProxy(QObject):
 

--- a/EasyReflectometryApp/Logic/Proxies/State.py
+++ b/EasyReflectometryApp/Logic/Proxies/State.py
@@ -1,9 +1,12 @@
 __author__ = 'github.com/arm61'
 
-from PySide2.QtCore import QObject, Signal, Property, Slot
+from PySide2.QtCore import QObject
+from PySide2.QtCore import Signal
+from PySide2.QtCore import Property
+from PySide2.QtCore import Slot
 
-from easyCore import np
-from easyCore.Utils.io.xml import XMLSerializer
+import numpy as np
+from easyscience.Utils.io.xml import XMLSerializer
 
 
 class StateProxy(QObject):

--- a/EasyReflectometryApp/Logic/Proxies/UndoRedo.py
+++ b/EasyReflectometryApp/Logic/Proxies/UndoRedo.py
@@ -2,11 +2,14 @@ __author__ = 'github.com/arm61'
 
 import re
 
-from PySide2.QtCore import QObject, Signal, Property, Slot
+from PySide2.QtCore import QObject
+from PySide2.QtCore import Signal
+from PySide2.QtCore import Property
+from PySide2.QtCore import Slot
 
-from easyCore import borg
-from easyCore.Objects.Groups import BaseCollection
-from easyCore.Objects.ObjectClasses import BaseObj
+from easyscience import borg
+from easyscience.Objects.Groups import BaseCollection
+from easyscience.Objects.ObjectClasses import BaseObj
 
 
 class UndoRedoProxy(QObject):

--- a/EasyReflectometryApp/Logic/PyQmlProxy.py
+++ b/EasyReflectometryApp/Logic/PyQmlProxy.py
@@ -1,8 +1,10 @@
 __author__ = 'github.com/arm61'
 
-from PySide2.QtCore import QObject, Signal, Property
+from PySide2.QtCore import QObject
+from PySide2.QtCore import Signal
+from PySide2.QtCore import Property
 
-from EasyReflectometry.calculators import CalculatorFactory
+from easyreflectometry.calculators import CalculatorFactory
 
 from .Proxies.Calculator import CalculatorProxy
 from .Proxies.Data import DataProxy

--- a/andpe/project.cif
+++ b/andpe/project.cif
@@ -1,5 +1,0 @@
-_name 'Example Project'
-_short_description 'reflectometry, 1D'
-_samples None
-_experiments None
-_modified '17.05.2024 08:24'

--- a/andpe/project.cif
+++ b/andpe/project.cif
@@ -1,0 +1,5 @@
+_name 'Example Project'
+_short_description 'reflectometry, 1D'
+_samples None
+_experiments None
+_modified '17.05.2024 08:24'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 # Information about the EasyReflectometryApp project.
 # Note that while the project is called EasyReflectometryApp
 # the application itself is EasyReflectometry. 
-name = "EasyReflectometry"
+name = "easyreflectometryapp"
 version = "0.0.10-dev"
 description = "Making reflectometry data analysis and modelling easy."
 authors = [
@@ -31,7 +31,7 @@ classifiers = [
 requires-python = ">=3.9, <3.10"
 dependencies = [
     'darkdetect>=0.3.1',
-    'EasyReflectometryLib>=0.0.6',
+    'easyreflectometry>=1.0.0',
     'easyApp @ git+https://github.com/easyScience/easyApp.git@develop',
     'matplotlib>=3.4.2',
     'toml>=0.10.2',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 # Note that while the project is called EasyReflectometryApp
 # the application itself is EasyReflectometry. 
 name = "EasyReflectometryApp"
-version = "0.0.10"
+version = "0.0.10-dev"
 description = "Making reflectometry data analysis and modelling easy."
 authors = [
     {name = "Andrew R. McCluskey", email = "andrew.mccluskey@ess.eu"}, 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ build-backend = "hatchling.build"
 # Information about the EasyReflectometryApp project.
 # Note that while the project is called EasyReflectometryApp
 # the application itself is EasyReflectometry. 
-name = "easyreflectometryapp"
-version = "0.0.10-dev"
+name = "EasyReflectometryApp"
+version = "0.0.10"
 description = "Making reflectometry data analysis and modelling easy."
 authors = [
     {name = "Andrew R. McCluskey", email = "andrew.mccluskey@ess.eu"}, 
@@ -31,7 +31,7 @@ classifiers = [
 requires-python = ">=3.9, <3.10"
 dependencies = [
     'darkdetect>=0.3.1',
-    'easyreflectometry>=1.0.0',
+    'easyreflectometry>=1.0.2',
     'easyApp @ git+https://github.com/easyScience/easyApp.git@develop',
     'matplotlib>=3.4.2',
     'toml>=0.10.2',

--- a/tools/Scripts/Config.py
+++ b/tools/Scripts/Config.py
@@ -46,7 +46,7 @@ class Config():
         self.repository_dir_suffix = self.__dict__['ci']['setup']['repository_dir_suffix']
 
         # Project
-        self.package_name = f'{self.app_name}App'
+        self.package_name = f'{self.app_name}'
         self.license_file = self.__dict__['ci']['setup']['license_file']
 
         # Certificates

--- a/tools/Scripts/FreezeApp.py
+++ b/tools/Scripts/FreezeApp.py
@@ -1,14 +1,20 @@
 __author__ = "github.com/AndrewSazonov"
 __version__ = '0.0.1'
 
-import os, sys
+import os
+import sys
 from typing import List
-import importlib
 import glob
-import PySide2, shiboken2
-import refnx, refl1d, periodictable
-import easyCore, EasyReflectometry, easyApp
-import Functions, Config
+import PySide2
+import shiboken2
+import refnx
+import refl1d
+import periodictable
+import easyscience
+import easyreflectometry
+import easyApp
+import Functions
+import Config
 from PyInstaller.__main__ import run as pyInstallerMain
 
 
@@ -38,8 +44,8 @@ def addedData() -> List[str]:
             {'from': refnx.__path__[0], 'to': 'refnx'},
             {'from': refl1d.__path__[0], 'to': 'refl1d'},
             {'from': periodictable.__path__[0], 'to': 'periodictable'},
-            {'from': easyCore.__path__[0], 'to': 'easyCore'},
-            {'from': EasyReflectometry.__path__[0], 'to': 'EasyReflectometryLib'},
+            {'from': easyscience.__path__[0], 'to': 'easyscience'},
+            {'from': easyreflectometry.__path__[0], 'to': 'easyreflectometryLib'},
             {'from': easyApp.__path__[0], 'to': 'easyApp'},
             {'from': 'utils.py', 'to': '.'},
             {'from': 'pyproject.toml', 'to': '.'}]


### PR DESCRIPTION
Imports.
- `easyscience`
- `easyreflectometry`
- one import per line
-  remove unused imports

More explicit instance creation
- no longer using `from_pars`

Get `numpy` directly rather than fetching from `easyscience`
