### PR TITLE
Fixes for crashes in the app

### DIFF
--- a/EasyReflectometryApp/Backends/Py/logic/layers.py
+++ b/EasyReflectometryApp/Backends/Py/logic/layers.py
@@ -3,6 +3,7 @@ from typing import Union
 from easyreflectometry import Project as ProjectLib
 from easyreflectometry.sample import LayerAreaPerMolecule
 from easyreflectometry.sample import LayerCollection
+from easyreflectometry.sample import Material
 
 
 class Layers:
@@ -42,7 +43,7 @@ class Layers:
 
     def add_new(self) -> None:
         if 'Si' not in [material.name for material in self._project_lib._materials]:
-            self._project_lib._materials.add_material('Si', 2.07, 0.0)
+            self._project_lib._materials.add_material(Material(name='Si', sld=2.07, isld=0.0))
         index_si = [material.name for material in self._project_lib._materials].index('Si')
         self._layers.add_layer()
         self._layers[-1].material = self._project_lib._materials[index_si]

--- a/EasyReflectometryApp/Backends/Py/sample.py
+++ b/EasyReflectometryApp/Backends/Py/sample.py
@@ -145,7 +145,6 @@ class Sample(QObject):
         self._project_lib.current_model_index = new_value
         self.modelsIndexChanged.emit()
         self.assembliesTableChanged.emit()
-        self._clearCacheAndEmitLayersChanged()
         self.externalRefreshPlot.emit()
 
     @Slot(str)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ dependencies = [
 ci = [
   'pyinstaller',
   'licensename',
-  'dephell_licenses'
+  'dephell_licenses',
+  'charset-normalizer<3.2',
 ]
 
 docs = [


### PR DESCRIPTION
1. Fixed setting Model Index - no layer update is needed. Calling this here caused circular loop of signals layer->model->layer->model->.... 
2. Fixed adding new layer. Adding new Material instance was done the "old" way which no longer is implemnted. This was also causing crashes.
3. Fixed MacOS installer
