### PR TITLE
Macos installer fix

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -17,8 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [ubuntu-22.04, ubuntu-24.04, windows-2022, macos-13, macos-14]
-        os: [macos-14]
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, macos-13, macos-14]
 
     steps:
       - name: Check-out repository

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -17,7 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, macos-13, macos-14]
+        # os: [ubuntu-22.04, ubuntu-24.04, windows-2022, macos-13, macos-14]
+        os: [macos-14]
 
     steps:
       - name: Check-out repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ dependencies = [
 ci = [
   'pyinstaller',
   'licensename',
-  'dephell_licenses'
+  'dephell_licenses',
+  'charset-normalizer<3.2',
 ]
 
 docs = [


### PR DESCRIPTION
Most current `charset_normalizer` fails on macos. Reverting to an older version, which works.
This needs reassessing at some point with updated version of the module.
