### PR TITLE
fix the duplicate model button enablement

### DIFF
--- a/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Basic/Groups/Fittables.qml
+++ b/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Basic/Groups/Fittables.qml
@@ -287,8 +287,10 @@ EaElements.GroupBox {
                 readOnly: true
                 width: EaStyle.Sizes.fontPixelSize * 6
                 text: {
-                    const value = Globals.BackendWrapper.analysisFitableParameters[Globals.BackendWrapper.analysisCurrentParameterIndex].value
-                    const error = Globals.BackendWrapper.analysisFitableParameters[Globals.BackendWrapper.analysisCurrentParameterIndex].error
+                    const par_index = Globals.BackendWrapper.analysisCurrentParameterIndex
+                    const params = Globals.BackendWrapper.analysisFitableParameters
+                    const value = params[par_index] !== undefined ? params[par_index].value : 0
+                    const error = params[par_index] !== undefined ? params[par_index].error : 0
                     return EaLogic.Utils.toDefaultPrecision(slider.from)
                 }
             }

--- a/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Groups/ModelSelector.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Groups/ModelSelector.qml
@@ -87,7 +87,8 @@ EaElements.GroupBox {
             }
 
             EaElements.SideBarButton {
-                enabled: (modelView.currentIndex > 0) ? true : false //When item is selected
+                // enabled: (modelView.currentIndex > 0) ? true : false //When item is selected
+                enabled: true
                 width: (EaStyle.Sizes.sideBarContentWidth - (2 * (EaStyle.Sizes.tableRowHeight + EaStyle.Sizes.fontPixelSize)) - EaStyle.Sizes.fontPixelSize) / 2
                 fontIcon: "clone"
                 text: qsTr("Duplicate model")


### PR DESCRIPTION
Models selector allows for model duplication.
This currently only allows for models with index > 0 to be duplicated. The first model in the list can't be copied.

The PR fixes the issue