### PR TITLE
limit binary signing to master branch

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Sign the binary using keypair alias
         if: |
-          runner.os == 'windows' && github.event_name == 'push'
+          runner.os == 'windows' && github.event_name == 'push' && env.BRANCH_NAME != 'master'
         run: |
            smctl sign --keypair-alias key_911959544 --input  ${{ env.SETUP_EXE_PATH }}
         shell: cmd


### PR DESCRIPTION
Our digicert signing cert allows only 1000 signatures for all the projects.
Let's be conservative and allow signing only for master branch pushes.

