### PR TITLE
fixed cases for easyapp modules

### DIFF
--- a/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Basic/Groups/Experiments.qml
+++ b/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Basic/Groups/Experiments.qml
@@ -1,9 +1,9 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
+import QtQuick
+import QtQuick.Controls
 
-import easyApp.Gui.Style as EaStyle
-import easyApp.Gui.Elements as EaElements
-import easyApp.Gui.Components as EaComponents
+import EasyApp.Gui.Style as EaStyle
+import EasyApp.Gui.Elements as EaElements
+import EasyApp.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Basic/Groups/ExperimentalData.qml
+++ b/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Basic/Groups/ExperimentalData.qml
@@ -2,8 +2,8 @@ import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtQuick.Dialogs as Dialogs1
 
-import easyApp.Gui.Style as EaStyle
-import easyApp.Gui.Elements as EaElements
+import EasyApp.Gui.Style as EaStyle
+import EasyApp.Gui.Elements as EaElements
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Basic/Groups/ExperimentalDataExplorer.qml
+++ b/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Basic/Groups/ExperimentalDataExplorer.qml
@@ -1,9 +1,9 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
 
-import easyApp.Gui.Style as EaStyle
-import easyApp.Gui.Elements as EaElements
-import easyApp.Gui.Components as EaComponents
+import EasyApp.Gui.Style as EaStyle
+import EasyApp.Gui.Elements as EaElements
+import EasyApp.Gui.Components as EaComponents
 
 //import Gui.Globals 1.0 as ExGlobals
 import Gui.Globals as Globals

--- a/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Basic/Groups/InstrumentParameters.qml
+++ b/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Basic/Groups/InstrumentParameters.qml
@@ -1,9 +1,9 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
 
-import easyApp.Gui.Style as EaStyle
-import easyApp.Gui.Elements as EaElements
-import easyApp.Gui.Components as EaComponents
+import EasyApp.Gui.Style as EaStyle
+import EasyApp.Gui.Elements as EaElements
+import EasyApp.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Basic/Layout.qml
+++ b/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Basic/Layout.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
+import QtQuick
+import QtQuick.Controls
 
-import easyApp.Gui.Components as EaComponents
+import EasyApp.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 import "./Groups" as Groups

--- a/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Advanced/Groups/QRange.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Advanced/Groups/QRange.qml
@@ -1,9 +1,9 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
 
-import easyApp.Gui.Style as EaStyle
-import easyApp.Gui.Elements as EaElements
-import easyApp.Gui.Components as EaComponents
+import EasyApp.Gui.Style as EaStyle
+import EasyApp.Gui.Elements as EaElements
+import EasyApp.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Advanced/Layout.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Advanced/Layout.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls 2.14
 //import QtQml.XmlListModel
 
 //import easyApp.Gui.Style 1.0 as EaStyle
-import easyApp.Gui.Components 1.0 as EaComponents
+import EasyApp.Gui.Components 1.0 as EaComponents
 
 import Gui.Globals as Globals
 import "./Groups" as Groups

--- a/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Layout.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Layout.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
 
-import easyApp.Gui.Components 1.0 as EaComponents
+import EasyApp.Gui.Components 1.0 as EaComponents
 
 import Gui.Globals as Globals
 import "./Groups" as Groups


### PR DESCRIPTION
In Experiments.qml, the imports use lowercase `easyApp` (old Qt5 convention from `src_qt5`), while the current module is registered as `EasyApp` (capital E). Windows doesn't care, but Linux does.

The file also uses the older Qt5-style import QtQuick 2.14 / import QtQuick.Controls 2.14 instead of the versionless Qt6 style used in the rest of the project.