### PR TITLE
moved to EasyApplication module

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -91,9 +91,6 @@ jobs:
       # - name: Run app in testmode and quit
       #   shell: bash
       #   run: |
-      #     cd ..
-      #     git clone --single-branch --branch get-rid-of-qt5compat https://github.com/easyscience/EasyApp.git
-      #     cd EasyReflectometryApp
       #     python EasyReflectometryApp/main.py --testmode
 
       - name: Create freezed python app bundle with PyInstaller

--- a/EasyReflectometryApp/Backends/Py/logic/summary.py
+++ b/EasyReflectometryApp/Backends/Py/logic/summary.py
@@ -1,9 +1,8 @@
 import logging
-from pathlib import Path
 from html import escape
+from pathlib import Path
 
 import numpy as np
-
 from easyreflectometry import Project as ProjectLib
 from easyreflectometry.summary import Summary as SummaryLib
 

--- a/EasyReflectometryApp/Backends/Py/plotting_1d.py
+++ b/EasyReflectometryApp/Backends/Py/plotting_1d.py
@@ -1,5 +1,5 @@
 import numpy as np
-from EasyApp.Logic.Logging import console
+from EasyApplication.Logic.Logging import console
 from easyreflectometry import Project as ProjectLib
 from easyreflectometry.data import DataSet1D
 from PySide6.QtCore import Property

--- a/EasyReflectometryApp/Backends/Py/project.py
+++ b/EasyReflectometryApp/Backends/Py/project.py
@@ -1,6 +1,5 @@
 import warnings
 
-from EasyApp.Logic.Utils.Utils import generalizePath
 from easyreflectometry import Project as ProjectLib
 from easyreflectometry.orso_utils import load_orso_model
 from orsopy.fileio import orso
@@ -9,6 +8,7 @@ from PySide6.QtCore import QObject
 from PySide6.QtCore import Signal
 from PySide6.QtCore import Slot
 
+from .helpers import IO
 from .logic.project import Project as ProjectLogic
 
 
@@ -85,7 +85,7 @@ class Project(QObject):
 
     @Slot(str)
     def load(self, path: str) -> None:
-        self._logic.load(generalizePath(path))
+        self._logic.load(IO.generalizePath(path))
         self.createdChanged.emit()
         self.nameChanged.emit()
         self.descriptionChanged.emit()
@@ -110,7 +110,7 @@ class Project(QObject):
     @Slot(str, bool)
     def sampleLoad(self, url: str, append: bool = True) -> None:
         # Load ORSO file content
-        orso_data = orso.load_orso(generalizePath(url))
+        orso_data = orso.load_orso(IO.generalizePath(url))
         # Load the sample model
         with warnings.catch_warnings(record=True) as caught_warnings:
             warnings.simplefilter('always')

--- a/EasyReflectometryApp/Backends/Py/py_backend.py
+++ b/EasyReflectometryApp/Backends/Py/py_backend.py
@@ -1,5 +1,5 @@
-from EasyApp.Logic.Logging import LoggerLevelHandler
-from EasyApp.Logic.Logging import console
+from EasyApplication.Logic.Logging import LoggerLevelHandler
+from EasyApplication.Logic.Logging import console
 from easyreflectometry import Project as ProjectLib
 from PySide6.QtCore import Property
 from PySide6.QtCore import QObject

--- a/EasyReflectometryApp/Gui/ApplicationWindow.qml
+++ b/EasyReflectometryApp/Gui/ApplicationWindow.qml
@@ -1,9 +1,9 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui as Gui
 import Gui.Globals as Globals

--- a/EasyReflectometryApp/Gui/Pages/Analysis/Layout.qml
+++ b/EasyReflectometryApp/Gui/Pages/Analysis/Layout.qml
@@ -2,10 +2,10 @@ import QtQuick
 import QtQuick.Controls
 //import QtQuick.XmlListModel 2.15
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui as Gui
 import Gui.Globals as Globals

--- a/EasyReflectometryApp/Gui/Pages/Analysis/MainContent/AnalysisView.qml
+++ b/EasyReflectometryApp/Gui/Pages/Analysis/MainContent/AnalysisView.qml
@@ -6,10 +6,10 @@ import QtQuick
 import QtQuick.Controls
 import QtCharts
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Charts as EaCharts
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Charts as EaCharts
 
 import Gui.Globals as Globals
 import "../../../Logic/MeasuredScatter.js" as MeasuredScatter

--- a/EasyReflectometryApp/Gui/Pages/Analysis/MainContent/CombinedView.qml
+++ b/EasyReflectometryApp/Gui/Pages/Analysis/MainContent/CombinedView.qml
@@ -7,10 +7,10 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import QtCharts
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Charts as EaCharts
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Charts as EaCharts
 
 import Gui as Gui
 import Gui.Globals as Globals

--- a/EasyReflectometryApp/Gui/Pages/Analysis/MainContent/ResidualsView.qml
+++ b/EasyReflectometryApp/Gui/Pages/Analysis/MainContent/ResidualsView.qml
@@ -6,9 +6,9 @@ import QtQuick
 import QtQuick.Controls
 import QtCharts
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Elements as EaElements
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Elements as EaElements
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Analysis/MainContent/SldView.qml
+++ b/EasyReflectometryApp/Gui/Pages/Analysis/MainContent/SldView.qml
@@ -6,7 +6,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
-import EasyApp.Gui.Style as EaStyle
+import EasyApplication.Gui.Style as EaStyle
 
 import Gui as Gui
 import Gui.Globals as Globals

--- a/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Advanced/Groups/Calculator.qml
+++ b/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Advanced/Groups/Calculator.qml
@@ -5,8 +5,8 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Advanced/Groups/Minimizer.qml
+++ b/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Advanced/Groups/Minimizer.qml
@@ -5,8 +5,8 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Advanced/Groups/ParamNames.qml
+++ b/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Advanced/Groups/ParamNames.qml
@@ -5,10 +5,10 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Advanced/Groups/PlotControl.qml
+++ b/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Advanced/Groups/PlotControl.qml
@@ -4,8 +4,8 @@
 
 import QtQuick
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
 
 import Gui as Gui
 

--- a/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Advanced/Layout.qml
+++ b/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Advanced/Layout.qml
@@ -4,8 +4,8 @@
 
 import QtQuick
 
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import "./Groups" as Groups
 

--- a/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Basic/Groups/Experiments.qml
+++ b/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Basic/Groups/Experiments.qml
@@ -1,9 +1,9 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Basic/Groups/Fittables.qml
+++ b/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Basic/Groups/Fittables.qml
@@ -6,11 +6,11 @@ import QtQuick
 import QtQuick.Controls
 import QtCharts
 
-import EasyApp.Gui.Logic as EaLogic
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Logic as EaLogic
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Basic/Groups/Fitting.qml
+++ b/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Basic/Groups/Fitting.qml
@@ -5,8 +5,8 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Basic/Layout.qml
+++ b/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Basic/Layout.qml
@@ -4,9 +4,9 @@
 
 import QtQuick
 
-import EasyApp.Gui.Style 1.0 as EaStyle
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Style 1.0 as EaStyle
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import "./Groups" as Groups
 import Gui.Globals as Globals

--- a/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Basic/Popups/FitStatusDialog.qml
+++ b/EasyReflectometryApp/Gui/Pages/Analysis/Sidebar/Basic/Popups/FitStatusDialog.qml
@@ -6,9 +6,9 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Experiment/Layout.qml
+++ b/EasyReflectometryApp/Gui/Pages/Experiment/Layout.qml
@@ -1,10 +1,10 @@
  import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Experiment/MainContent/ExperimentView.qml
+++ b/EasyReflectometryApp/Gui/Pages/Experiment/MainContent/ExperimentView.qml
@@ -6,10 +6,10 @@ import QtQuick
 import QtQuick.Controls
 import QtCharts
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Charts as EaCharts
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Charts as EaCharts
 
 import Gui.Globals as Globals
 import "../../../Logic/MeasuredScatter.js" as MeasuredScatter

--- a/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Advanced/Groups/PlotControl.qml
+++ b/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Advanced/Groups/PlotControl.qml
@@ -5,8 +5,8 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Advanced/Layout.qml
+++ b/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Advanced/Layout.qml
@@ -4,8 +4,8 @@
 
 import QtQuick
 
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import "./Groups" as Groups
 

--- a/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Basic/Groups/ExperimentalData.qml
+++ b/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Basic/Groups/ExperimentalData.qml
@@ -2,8 +2,8 @@ import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtQuick.Dialogs as Dialogs1
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Basic/Groups/ExperimentalDataExplorer.qml
+++ b/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Basic/Groups/ExperimentalDataExplorer.qml
@@ -1,9 +1,9 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 //import Gui.Globals 1.0 as ExGlobals
 import Gui.Globals as Globals

--- a/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Basic/Groups/InstrumentParameters.qml
+++ b/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Basic/Groups/InstrumentParameters.qml
@@ -1,9 +1,9 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Basic/Layout.qml
+++ b/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Basic/Layout.qml
@@ -1,7 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 import "./Groups" as Groups

--- a/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Basic/Popups/OpenExperimentFile.qml
+++ b/EasyReflectometryApp/Gui/Pages/Experiment/Sidebar/Basic/Popups/OpenExperimentFile.qml
@@ -2,8 +2,8 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Dialogs
 
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Home/Layout.qml
+++ b/EasyReflectometryApp/Gui/Pages/Home/Layout.qml
@@ -1,8 +1,8 @@
 import QtQuick
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Elements as EaElements
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Elements as EaElements
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Home/Popups/About.qml
+++ b/EasyReflectometryApp/Gui/Pages/Home/Popups/About.qml
@@ -1,7 +1,7 @@
 import QtQuick
 
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Project/Layout.qml
+++ b/EasyReflectometryApp/Gui/Pages/Project/Layout.qml
@@ -1,8 +1,8 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Project/MainContent/Description.qml
+++ b/EasyReflectometryApp/Gui/Pages/Project/MainContent/Description.qml
@@ -4,8 +4,8 @@
 
 import QtQuick
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Project/Sidebar/Basic/Groups/GetStarted.qml
+++ b/EasyReflectometryApp/Gui/Pages/Project/Sidebar/Basic/Groups/GetStarted.qml
@@ -1,11 +1,11 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
-import EasyApp.Gui.Logic as EaLogic
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
+import EasyApplication.Gui.Logic as EaLogic
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Project/Sidebar/Basic/Layout.qml
+++ b/EasyReflectometryApp/Gui/Pages/Project/Sidebar/Basic/Layout.qml
@@ -1,8 +1,8 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Project/Sidebar/Basic/Popups/OpenJsonFile.qml
+++ b/EasyReflectometryApp/Gui/Pages/Project/Sidebar/Basic/Popups/OpenJsonFile.qml
@@ -2,8 +2,8 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Dialogs
 
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Project/Sidebar/Basic/Popups/ProjectDescription.qml
+++ b/EasyReflectometryApp/Gui/Pages/Project/Sidebar/Basic/Popups/ProjectDescription.qml
@@ -1,8 +1,8 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Sample/Layout.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/Layout.qml
@@ -1,10 +1,10 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Sample/MainContent/CombinedView.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/MainContent/CombinedView.qml
@@ -7,10 +7,10 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import QtCharts
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Charts as EaCharts
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Charts as EaCharts
 
 import Gui as Gui
 import Gui.Globals as Globals

--- a/EasyReflectometryApp/Gui/Pages/Sample/MainContent/SampleView.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/MainContent/SampleView.qml
@@ -6,10 +6,10 @@ import QtQuick
 import QtQuick.Controls
 import QtCharts
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Charts as EaCharts
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Charts as EaCharts
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Advanced/Groups/Constraints.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Advanced/Groups/Constraints.qml
@@ -1,8 +1,8 @@
 import QtQuick
 import QtQuick.Controls
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Advanced/Groups/ModelConstraints.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Advanced/Groups/ModelConstraints.qml
@@ -1,8 +1,8 @@
 import QtQuick
 import QtQuick.Controls
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Advanced/Groups/PlotControl.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Advanced/Groups/PlotControl.qml
@@ -5,8 +5,8 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Advanced/Groups/QRange.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Advanced/Groups/QRange.qml
@@ -1,9 +1,9 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Advanced/Layout.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Advanced/Layout.qml
@@ -2,8 +2,8 @@ import QtQuick 2.14
 import QtQuick.Controls 2.14
 //import QtQml.XmlListModel
 
-//import easyApp.Gui.Style 1.0 as EaStyle
-import EasyApp.Gui.Components 1.0 as EaComponents
+//import EasyApplication.Gui.Style 1.0 as EaStyle
+import EasyApplication.Gui.Components 1.0 as EaComponents
 
 import Gui.Globals as Globals
 import "./Groups" as Groups

--- a/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Groups/Assemblies/MultiLayer.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Groups/Assemblies/MultiLayer.qml
@@ -1,9 +1,9 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Groups/Assemblies/RepeatingMultiLayer.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Groups/Assemblies/RepeatingMultiLayer.qml
@@ -1,9 +1,9 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 import "../Assemblies" as Assemblies

--- a/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Groups/Assemblies/SurfactantLayer.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Groups/Assemblies/SurfactantLayer.qml
@@ -1,9 +1,9 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Groups/LoadSample.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Groups/LoadSample.qml
@@ -2,8 +2,8 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Dialogs
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Groups/MaterialEditor.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Groups/MaterialEditor.qml
@@ -1,9 +1,9 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Groups/ModelEditor.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Groups/ModelEditor.qml
@@ -1,9 +1,9 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 import "./Assemblies" as Assemblies

--- a/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Groups/ModelSelector.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Groups/ModelSelector.qml
@@ -1,9 +1,9 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Layout.qml
+++ b/EasyReflectometryApp/Gui/Pages/Sample/Sidebar/Basic/Layout.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
 
-import EasyApp.Gui.Components 1.0 as EaComponents
+import EasyApplication.Gui.Components 1.0 as EaComponents
 
 import Gui.Globals as Globals
 import "./Groups" as Groups

--- a/EasyReflectometryApp/Gui/Pages/Summary/Layout.qml
+++ b/EasyReflectometryApp/Gui/Pages/Summary/Layout.qml
@@ -5,10 +5,10 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Summary/MainContent/Summary.qml
+++ b/EasyReflectometryApp/Gui/Pages/Summary/MainContent/Summary.qml
@@ -5,9 +5,9 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Animations as EaAnimations
-import EasyApp.Gui.Elements as EaElements
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Animations as EaAnimations
+import EasyApplication.Gui.Elements as EaElements
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Summary/Sidebar/Basic/Groups/Export.qml
+++ b/EasyReflectometryApp/Gui/Pages/Summary/Sidebar/Basic/Groups/Export.qml
@@ -7,9 +7,9 @@ import QtQuick.Controls
 import QtQuick.Dialogs
 import QtCore
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Logic as EaLogic
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Logic as EaLogic
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Summary/Sidebar/Basic/Groups/ExportPlots.qml
+++ b/EasyReflectometryApp/Gui/Pages/Summary/Sidebar/Basic/Groups/ExportPlots.qml
@@ -6,9 +6,9 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Dialogs
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Logic as EaLogic
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Logic as EaLogic
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Summary/Sidebar/Basic/Groups/SaveConfirmationDialog.qml
+++ b/EasyReflectometryApp/Gui/Pages/Summary/Sidebar/Basic/Groups/SaveConfirmationDialog.qml
@@ -5,8 +5,8 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
 
 
 EaElements.Dialog {

--- a/EasyReflectometryApp/Gui/Pages/Summary/Sidebar/Basic/Layout.qml
+++ b/EasyReflectometryApp/Gui/Pages/Summary/Sidebar/Basic/Layout.qml
@@ -4,8 +4,8 @@
 
 import QtQuick
 
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/Pages/Summary/Sidebar/Extra/Groups/Empty.qml
+++ b/EasyReflectometryApp/Gui/Pages/Summary/Sidebar/Extra/Groups/Empty.qml
@@ -4,8 +4,8 @@
 
 import QtQuick
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
 
 
 Column {}

--- a/EasyReflectometryApp/Gui/Pages/Summary/Sidebar/Extra/Layout.qml
+++ b/EasyReflectometryApp/Gui/Pages/Summary/Sidebar/Extra/Layout.qml
@@ -5,8 +5,8 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/PlotControlRefLines.qml
+++ b/EasyReflectometryApp/Gui/PlotControlRefLines.qml
@@ -5,8 +5,8 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Elements as EaElements
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Elements as EaElements
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/SideBarWithFooter.qml
+++ b/EasyReflectometryApp/Gui/SideBarWithFooter.qml
@@ -6,9 +6,9 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Controls.Material
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Animations as EaAnimations
-import EasyApp.Gui.Elements as EaElements
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Animations as EaAnimations
+import EasyApplication.Gui.Elements as EaElements
 
 Item {
     id: sideBarContainer

--- a/EasyReflectometryApp/Gui/SldChart.qml
+++ b/EasyReflectometryApp/Gui/SldChart.qml
@@ -6,9 +6,9 @@ import QtQuick
 import QtQuick.Controls
 import QtCharts
 
-import EasyApp.Gui.Style as EaStyle
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Elements as EaElements
+import EasyApplication.Gui.Style as EaStyle
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Elements as EaElements
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/Gui/StatusBar.qml
+++ b/EasyReflectometryApp/Gui/StatusBar.qml
@@ -1,9 +1,9 @@
 import QtQuick
 import QtQuick.Controls
 
-import EasyApp.Gui.Globals as EaGlobals
-import EasyApp.Gui.Elements as EaElements
-import EasyApp.Gui.Components as EaComponents
+import EasyApplication.Gui.Globals as EaGlobals
+import EasyApplication.Gui.Elements as EaElements
+import EasyApplication.Gui.Components as EaComponents
 
 import Gui.Globals as Globals
 

--- a/EasyReflectometryApp/main.py
+++ b/EasyReflectometryApp/main.py
@@ -5,7 +5,8 @@ import argparse
 import sys
 from pathlib import Path
 
-from EasyApp.Logic.Logging import console
+import EasyApplication
+from EasyApplication.Logic.Logging import console
 from PySide6.QtCore import QUrl
 from PySide6.QtCore import qInstallMessageHandler
 from PySide6.QtGui import QIcon
@@ -24,6 +25,9 @@ except ImportError:  # Running from installer
     INSTALLER = True
 
 CURRENT_DIR = Path(__file__).parent  # path to qml components of the current project
+# Path to the directory that *contains* the installed EasyApplication package, so that
+# QML statements like `import EasyApplication.Gui.Style` can be resolved.
+EASYAPP_IMPORT_DIR = Path(EasyApplication.__path__[0]).parent
 
 
 if __name__ == '__main__':
@@ -51,11 +55,12 @@ if __name__ == '__main__':
         path_main_qml = QUrl.fromLocalFile(CURRENT_DIR / 'EasyReflectometryApp' / 'Gui' / 'ApplicationWindow.qml')
         engine.addImportPath(CURRENT_DIR / 'EasyReflectometryApp')
         engine.addImportPath(CURRENT_DIR)
+        engine.addImportPath(str(EASYAPP_IMPORT_DIR))
         console.debug('Paths added where QML searches for components')
     else:  # Running locally
-        path_main_qml = path_main_qml = CURRENT_DIR / 'Gui' / 'ApplicationWindow.qml'
+        path_main_qml = CURRENT_DIR / 'Gui' / 'ApplicationWindow.qml'
         engine.addImportPath(CURRENT_DIR)
-        engine.addImportPath(CURRENT_DIR / '..' / '..' / 'EasyApp' / 'src')
+        engine.addImportPath(str(EASYAPP_IMPORT_DIR))
         console.debug('Paths added where QML searches for components')
 
     engine.load(path_main_qml)

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -2,10 +2,10 @@
 
 To make the installation of EasyReflectometry as easy as possible, we prepare packaged releases for three major operating systems: 
 
-- [Windows](https://github.com/EasyScience/EasyReflectometryApp/releases/download/v1.2.0/EasyReflectometryApp_v1.2.0_windows-2022.exe)
-- [MacOS](https://github.com/EasyScience/EasyReflectometryApp/releases/download/v1.2.0/EasyReflectometryApp_v1.2.0_macos-14-AppleSilicon.zip) (ARM)
-- [Linux](https://github.com/EasyScience/EasyReflectometryApp/releases/download/v1.2.0/EasyReflectometryApp_v1.2.0_ubuntu-22.04) (built on Ubuntu-22.04)
-- [Linux](https://github.com/EasyScience/EasyReflectometryApp/releases/download/v1.2.0/EasyReflectometryApp_v1.2.0_ubuntu-24.04) (built on Ubuntu-22.04)
+- [Windows](https://github.com/EasyScience/EasyReflectometryApp/releases/download/v1.2.1/EasyReflectometryApp_v1.2.1_windows-2022.exe)
+- [MacOS](https://github.com/EasyScience/EasyReflectometryApp/releases/download/v1.2.1/EasyReflectometryApp_v1.2.1_macos-14-AppleSilicon.zip) (ARM)
+- [Linux](https://github.com/EasyScience/EasyReflectometryApp/releases/download/v1.2.1/EasyReflectometryApp_v1.2.1_ubuntu-22.04) (built on Ubuntu-22.04)
+- [Linux](https://github.com/EasyScience/EasyReflectometryApp/releases/download/v1.2.1/EasyReflectometryApp_v1.2.1_ubuntu-24.04) (built on Ubuntu-22.04)
 
 If the relevant EasyReflectometry installation does not work on your system, then please try installation from source. 
 
@@ -15,20 +15,16 @@ If the relevant EasyReflectometry installation does not work on your system, the
   ```
   git clone https://github.com/easyScience/EasyReflectometryApp
   ```
-2. Clone **EasyApp** repo from GitHub
+2. Go to **EasyReflectometryApp** directory
+3. Create miniforge conda environment with the name era_313 for **EasyReflectometryApp**
   ```
-  git clone https://github.com/easyScience/EasyApp
-  ```
-3. Go to **EasyReflectometryApp** directory
-4. Create miniforge conda environment with the name era_311 for **EasyReflectometryApp**
-  ```
-  conda create --name era_311 python=3.11
+  conda create --name era_313 python=3.13
   ```  
-5. Create environment for **EasyReflectometryApp** and install it and its dependences using **pip** 
+4. Create environment for **EasyReflectometryApp** and install it and its dependences using **pip** 
   ```
   pip install -e .
   ```  
-6. Launch **EasyReflectometry** application in the created environment
+5. Launch **EasyReflectometry** application in the created environment
   ```
   python EasyReflectometryApp/main.py
   ```

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -12,12 +12,10 @@ If the relevant EasyReflectometry installation does not work on your system, the
 
 1. Clone EasyReflectometryApp repo from GitHub
     > git clone https://github.com/easyScience/EasyReflectometryApp
-2. Clone EasyApp repo from GitHub
-    > git clone https://github.com/easyScience/EasyApp
-3. Go to EasyReflectometryApp directory
-4. Create miniforge conda environment with the name era_311 for EasyReflectometryApp
-    > conda create --name era_311 python=3.11
-5. Create environment for EasyReflectometryApp and install it and its dependences using pip
+2. Go to EasyReflectometryApp directory
+3. Create miniforge conda environment with the name era_313 for EasyReflectometryApp
+    > conda create --name era_313 python=3.13
+4. Create environment for EasyReflectometryApp and install it and its dependences using pip
     > pip install -e .
-6. Launch EasyReflectometry application in the created environment
+5. Launch EasyReflectometry application in the created environment
     > python EasyReflectometryApp/main.py

--- a/tests/test_py_backend.py
+++ b/tests/test_py_backend.py
@@ -1,4 +1,3 @@
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from PySide6.QtCore import QObject

--- a/tests/test_py_project.py
+++ b/tests/test_py_project.py
@@ -64,7 +64,7 @@ def test_setters_emit_only_on_change(monkeypatch, qcore_application):
 
 def test_load_create_reset_and_signals(monkeypatch, qcore_application):
     project = _build_project(monkeypatch)
-    monkeypatch.setattr(project_module, 'generalizePath', lambda path: f'gen:{path}')
+    monkeypatch.setattr(project_module.IO, 'generalizePath', lambda path: f'gen:{path}')
 
     counts = {'created': 0, 'external_created': 0, 'external_loaded': 0, 'external_reset': 0}
     project.createdChanged.connect(lambda: counts.__setitem__('created', counts['created'] + 1))
@@ -86,7 +86,7 @@ def test_load_create_reset_and_signals(monkeypatch, qcore_application):
 
 def test_sample_load_append_and_replace(monkeypatch, qcore_application):
     project = _build_project(monkeypatch)
-    monkeypatch.setattr(project_module, 'generalizePath', lambda path: f'gen:{path}')
+    monkeypatch.setattr(project_module.IO, 'generalizePath', lambda path: f'gen:{path}')
     monkeypatch.setattr(project_module.orso, 'load_orso', lambda path: f'orso:{path}')
     monkeypatch.setattr(project_module, 'load_orso_model', lambda _orso_data: 'sample-model')
 
@@ -103,7 +103,7 @@ def test_sample_load_append_and_replace(monkeypatch, qcore_application):
 
 def test_sample_load_emits_warning_when_model_missing(monkeypatch, qcore_application):
     project = _build_project(monkeypatch)
-    monkeypatch.setattr(project_module, 'generalizePath', lambda path: path)
+    monkeypatch.setattr(project_module.IO, 'generalizePath', lambda path: path)
     monkeypatch.setattr(project_module.orso, 'load_orso', lambda _path: 'orso-data')
 
     def _warn_and_return_none(_orso_data):

--- a/tests/test_qml_fitting_progress_ui.py
+++ b/tests/test_qml_fitting_progress_ui.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tools/Scripts/FreezeApp.py
+++ b/tools/Scripts/FreezeApp.py
@@ -8,7 +8,7 @@ import site
 import sys
 
 import Config
-import EasyApp
+import EasyApplication as EasyApp
 import Functions
 import periodictable
 import PySide6
@@ -49,7 +49,7 @@ def addedData():
         {'from': refnx.__path__[0], 'to': 'refnx'},
         {'from': refl1d.__path__[0], 'to': 'refl1d'},
         {'from': periodictable.__path__[0], 'to': 'periodictable'},  #            {'from': cryspy.__path__[0], 'to': 'cryspy'},
-        {'from': EasyApp.__path__[0], 'to': 'EasyApp'},
+        {'from': EasyApp.__path__[0], 'to': 'easyapplication'},
         {'from': 'utils.py', 'to': '.'},
         {'from': 'pyproject.toml', 'to': '.'},
     ]


### PR DESCRIPTION
This pull request updates the project to use the new `EasyApplication` package namespace instead of the old `EasyApp` namespace throughout both the Python backend and QML frontend. It also refactors how the `generalizePath` utility is accessed in the backend, improving code organization and maintainability.

**Migration to EasyApplication namespace:**

* All QML import statements have been updated from `EasyApp` to `EasyApplication` to reflect the new package structure, ensuring consistency and preventing import errors in the GUI. 
* Python imports of logging utilities have been updated to use `EasyApplication.Logic.Logging` instead of `EasyApp.Logic.Logging`. 
**Backend utility refactoring:**

* The `generalizePath` utility is now accessed via the new `IO` helper module (`IO.generalizePath`) instead of being imported directly from `EasyApp.Logic.Utils.Utils`, improving encapsulation and code clarity. 

