### PR TITLE
make links clickable

### DIFF
--- a/EasyReflectometryApp/Gui/Pages/Summary/MainContent/Summary.qml
+++ b/EasyReflectometryApp/Gui/Pages/Summary/MainContent/Summary.qml
@@ -47,6 +47,13 @@ Rectangle {
 
             textFormat: TextEdit.RichText
             text: Globals.BackendWrapper.summaryAsHtml
+
+            onLinkActivated: (link) => {
+                if (link.startsWith("nametooltip:")) {
+                    return
+                }
+                Qt.openUrlExternally(link)
+            }
         }
         // Main text area
 


### PR DESCRIPTION
This pull request introduces a handler for activated links in the summary view to improve user interaction. Specifically, it prevents links starting with `nametooltip:` from triggering external navigation, while allowing all other links to open in the user's default browser.

