### PR TITLE
fix: correct release_data typo and dict annotation in EasyReflectometryApp

### DIFF
--- a/EasyReflectometryApp/Backends/Py/home.py
+++ b/EasyReflectometryApp/Backends/Py/home.py
@@ -13,14 +13,14 @@ class Home(QObject):
         super().__init__(parent)
 
     @Property('QVariant', constant=True)
-    def version(self) -> dict[str:str]:
+    def version(self) -> dict[str, str]:
         return {
             'number': PYPROJECT['project']['version'],
-            'date': PYPROJECT['project']['release_data'],
+            'date': PYPROJECT['project']['release_date'],
         }
 
     @Property('QVariant', constant=True)
-    def urls(self) -> dict[str:str]:
+    def urls(self) -> dict[str, str]:
         return {
             'homepage': PYPROJECT['project']['urls']['homepage'],
             'issues': PYPROJECT['project']['urls']['issues'],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = 'hatchling.build'
 [project]
 name = 'EasyReflectometryApp'
 version = '1.3.1'
-release_data = '1 May 2026'
+release_date = '1 May 2026'
 description = "Making reflectometry data analysis and modelling easy."
 authors = [
     {name = "Andrew R. McCluskey"}, 


### PR DESCRIPTION
## Summary
Fixes issue #323 - two related typos:

1. **Misspelled pyproject key**: `release_data` → `release_date` (PEP-621 compliance)
2. **Reference update in home.py**: `PYPROJECT['project']['release_data']` → `PYPROJECT['project']['release_date']`  
3. **Dict annotation typo fix**: `dict[str:str]` → `dict[str, str]` (two occurrences in home.py lines 16 and 23)

## Changes
- `pyproject.toml`: `release_data` → `release_date`
- `EasyReflectometryApp/Backends/Py/home.py`: Updated pyproject key reference + corrected type annotations

## Testing
- Verify app imports without `toml.load` crash
- Confirm type-checker no longer flags `dict[str:str]` as invalid syntax

## Fixes
- Closes #323